### PR TITLE
feat: 강의별 활동 목록 조회 API

### DIFF
--- a/src/main/java/sopio/acha/domain/activity/application/ActivityService.java
+++ b/src/main/java/sopio/acha/domain/activity/application/ActivityService.java
@@ -25,6 +25,9 @@ import sopio.acha.domain.activity.infrastructure.ActivityRepository;
 import sopio.acha.domain.activity.presentation.exception.FailedParsingActivityDataException;
 import sopio.acha.domain.activity.presentation.response.ActivityResponse;
 import sopio.acha.domain.activity.presentation.response.ActivitySummaryListResponse;
+import sopio.acha.domain.activity.presentation.response.ActivityWeekListResponse;
+import sopio.acha.domain.lecture.application.LectureService;
+import sopio.acha.domain.lecture.domain.Lecture;
 import sopio.acha.domain.member.domain.Member;
 import sopio.acha.domain.memberLecture.application.MemberLectureService;
 import sopio.acha.domain.memberLecture.domain.MemberLecture;
@@ -34,6 +37,7 @@ import sopio.acha.domain.memberLecture.domain.MemberLecture;
 public class ActivityService {
 	private final ActivityRepository activityRepository;
 	private final MemberLectureService memberLectureService;
+	private final LectureService lectureService;
 
 	@Transactional
 	@Scheduled(fixedRate = 5, timeUnit = TimeUnit.MINUTES)
@@ -64,6 +68,14 @@ public class ActivityService {
 		List<Activity> activities = activityRepository.findTop10ByMemberIdAndDeadlineAfterOrderByDeadlineAsc(
 			currentMember.getId(), LocalDateTime.now());
 		return ActivitySummaryListResponse.from(activities);
+	}
+
+	@Transactional
+	public ActivityWeekListResponse getLectureActivityList(Member currentMember, String code) {
+		Lecture targetLecture = lectureService.getLectureByCode(code);
+		List<Activity> activities = activityRepository.findAllByMemberIdAndLectureIdOrderByWeekAsc(
+			currentMember.getId(), targetLecture.getId());
+		return ActivityWeekListResponse.from(targetLecture, activities);
 	}
 
 	private void saveExtractedActivity(List<MemberLecture> currentLectures, ObjectMapper objectMapper) {

--- a/src/main/java/sopio/acha/domain/activity/infrastructure/ActivityRepository.java
+++ b/src/main/java/sopio/acha/domain/activity/infrastructure/ActivityRepository.java
@@ -12,4 +12,5 @@ import sopio.acha.domain.activity.domain.Activity;
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
 	boolean existsActivityByTitleAndMemberId(String title, String memberId);
 	List<Activity> findTop10ByMemberIdAndDeadlineAfterOrderByDeadlineAsc(String memberId, LocalDateTime now);
+	List<Activity> findAllByMemberIdAndLectureIdOrderByWeekAsc(String memberId, Long lectureId);
 }

--- a/src/main/java/sopio/acha/domain/activity/presentation/ActivityController.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/ActivityController.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import sopio.acha.common.auth.annotation.CurrentMember;
 import sopio.acha.domain.activity.application.ActivityService;
 import sopio.acha.domain.activity.presentation.response.ActivitySummaryListResponse;
+import sopio.acha.domain.activity.presentation.response.ActivityWeekListResponse;
 import sopio.acha.domain.member.domain.Member;
 
 @RestController
@@ -37,6 +39,16 @@ public class ActivityController {
 		@CurrentMember Member currentMember
 	) {
 		ActivitySummaryListResponse response = activityService.getMyActivityList(currentMember);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/lecture")
+	@Operation(summary = "강의별 활동 목록 조회 API", description = "강의별 활동 목록을 조회합니다.")
+	public ResponseEntity<ActivityWeekListResponse> getLectureActivityList(
+		@CurrentMember Member currentMember,
+		@RequestParam String code
+	) {
+		ActivityWeekListResponse response = activityService.getLectureActivityList(currentMember, code);
 		return ResponseEntity.ok().body(response);
 	}
 }

--- a/src/main/java/sopio/acha/domain/activity/presentation/response/ActivitySummaryListResponse.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/response/ActivitySummaryListResponse.java
@@ -1,12 +1,18 @@
 package sopio.acha.domain.activity.presentation.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sopio.acha.domain.activity.domain.Activity;
 
 @Builder
 public record ActivitySummaryListResponse(
+	@Schema(description = "활동 목록",
+		example = "[{\"lectureTitle\":\"컴퓨터 네트워크\",\"title\":\"활동명 예시\",\"type\":\"ASSIGNMENT\",\"code\":\"50251\",\"deadlineDay\":\"2021-06-30\",\"deadlineTime\":\"23:59:59\",\"link\":\"https://lms.kyonggi.ac.kr/\"}]",
+		requiredMode = REQUIRED)
 	List<ActivitySummaryResponse> contents
 ) {
 	public static ActivitySummaryListResponse from(List<Activity> activities) {

--- a/src/main/java/sopio/acha/domain/activity/presentation/response/ActivitySummaryResponse.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/response/ActivitySummaryResponse.java
@@ -16,7 +16,7 @@ public record ActivitySummaryResponse(
 	String title,
 
 	@Schema(description = "활동 타입", example = "ASSIGNMENT", requiredMode = REQUIRED)
-	String activityType,
+	String type,
 
 	@Schema(description = "활동 코드", example = "50251", requiredMode = REQUIRED)
 	String code,
@@ -34,7 +34,7 @@ public record ActivitySummaryResponse(
 		return ActivitySummaryResponse.builder()
 			.lectureTitle(activity.getLecture().getTitle())
 			.title(activity.getTitle())
-			.activityType(activity.getType().toString())
+			.type(activity.getType().toString())
 			.code(activity.getCode())
 			.deadlineDay(activity.getDeadline().toLocalDate().toString())
 			.deadlineTime(activity.getDeadline().toLocalTime().toString())

--- a/src/main/java/sopio/acha/domain/activity/presentation/response/ActivityWeekListResponse.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/response/ActivityWeekListResponse.java
@@ -1,0 +1,34 @@
+package sopio.acha.domain.activity.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import sopio.acha.domain.activity.domain.Activity;
+import sopio.acha.domain.lecture.domain.Lecture;
+
+@Builder
+public record ActivityWeekListResponse(
+	@Schema(description = "강의 제목", example = "컴퓨터 네트워크", requiredMode = REQUIRED)
+	String lectureTitle,
+
+	@Schema(description = "교수 이름", example = "홍길동", requiredMode = REQUIRED)
+	String professor,
+
+	@Schema(description = "활동 목록",
+		example = "[{\"weekStartAt\":\"2024-09-02\",\"weekEndAt\":\"2024-09-08\",\"week\":2,\"title\":\"활동명 예시\",\"code\":\"50251\",\"link\":\"https://lms.kyonggi.ac.kr/\",\"type\":\"ASSIGNMENT\"}]",
+		requiredMode = REQUIRED)
+	List<ActivityWeekResponse> contents
+) {
+	public static ActivityWeekListResponse from(Lecture lecture, List<Activity> activities) {
+		return ActivityWeekListResponse.builder()
+			.lectureTitle(lecture.getTitle())
+			.professor(lecture.getProfessor())
+			.contents(activities.stream()
+				.map(ActivityWeekResponse::from)
+				.toList())
+			.build();
+	}
+}

--- a/src/main/java/sopio/acha/domain/activity/presentation/response/ActivityWeekResponse.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/response/ActivityWeekResponse.java
@@ -1,0 +1,52 @@
+package sopio.acha.domain.activity.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import sopio.acha.domain.activity.domain.Activity;
+
+@Builder
+public record ActivityWeekResponse(
+	@Schema(description = "주차 시작 날짜", example = "2024-09-02", requiredMode = REQUIRED)
+	String weekStartAt,
+
+	@Schema(description = "주차 종료 날짜", example = "2024-09-08", requiredMode = REQUIRED)
+	String weekEndAt,
+
+	@Schema(description = "주차", example = "2", requiredMode = REQUIRED)
+	int week,
+
+	@Schema(description = "활동 이름", example = "활동명 예시", requiredMode = REQUIRED)
+	String title,
+
+	@Schema(description = "활동 코드", example = "50251", requiredMode = NOT_REQUIRED)
+	String code,
+
+	@Schema(description = "활동 링크", example = "https://lms.kyonggi.ac.kr/", requiredMode = NOT_REQUIRED)
+	String link,
+
+	@Schema(description = "활동 타입", example = "ASSIGNMENT", requiredMode = REQUIRED)
+	String type
+) {
+	public static ActivityWeekResponse from(Activity activity) {
+		LocalDate deadlineDate = activity.getDeadline().toLocalDate();
+		LocalDate startOfWeek = deadlineDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+		LocalDate endOfWeek = deadlineDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+		return ActivityWeekResponse.builder()
+			.weekStartAt(startOfWeek.toString())
+			.weekEndAt(endOfWeek.toString())
+			.week(activity.getWeek())
+			.title(activity.getTitle())
+			.code(activity.getCode())
+			.link(activity.getLink())
+			.type(activity.getType().toString())
+			.build();
+	}
+}

--- a/src/main/java/sopio/acha/domain/lecture/application/LectureService.java
+++ b/src/main/java/sopio/acha/domain/lecture/application/LectureService.java
@@ -73,6 +73,11 @@ public class LectureService {
 		}
 	}
 
+	public Lecture getLectureByCode(String code) {
+		return lectureRepository.findByCode(code)
+			.orElseThrow(LectureNotFoundException::new);
+	}
+
 	private Lecture getByIdentifier(String identifier) {
 		return lectureRepository.findByIdentifier(identifier)
 			.orElseThrow(LectureNotFoundException::new);

--- a/src/main/java/sopio/acha/domain/lecture/infrastructure/LectureRepository.java
+++ b/src/main/java/sopio/acha/domain/lecture/infrastructure/LectureRepository.java
@@ -13,4 +13,6 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
 	boolean existsByIdentifier(String identifier);
 
 	Optional<Lecture> findByIdentifier(String identifier);
+
+	Optional<Lecture> findByCode(String code);
 }


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

feat: 강의별 활동 목록 조회 API




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 강의 코드와 회원 정보를 기반으로 특정 강의에 대한 주별 활동 목록을 조회할 수 있는 기능이 추가되었습니다.
	- 새로운 API 엔드포인트를 통해 사용자는 강의 제목, 담당 교수 및 주별 활동 정보를 한눈에 확인할 수 있습니다.
- **문서 개선**
	- 응답 데이터 구조와 관련된 설명 및 예시가 강화되어, API 문서(예: Swagger)가 보다 명확하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->