### PR TITLE
Hotfix/activity

### DIFF
--- a/src/main/java/sopio/acha/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/sopio/acha/common/exception/GlobalExceptionCode.java
@@ -2,6 +2,7 @@ package sopio.acha.common.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import org.springframework.http.HttpStatus;
 
@@ -14,6 +15,7 @@ public enum GlobalExceptionCode implements ExceptionCode{
 	EXTRACTOR_ERROR(BAD_REQUEST, "추출기 오류가 발생했습니다."),
 	INVALID_INPUT(BAD_REQUEST, "유효한 입력 형식이 아닙니다."),
 	SERVER_ERROR(INTERNAL_SERVER_ERROR, "예상치 못한 문제가 발생했습니다."),
+	KUTIS_PASSWORD_ERROR(UNAUTHORIZED, "KUTIS 비밀번호 변경이 필요합니다."),
 	// KUTIS_SERVER_ERROR(INTERNAL_SERVER_ERROR, "KUTIS 서버에서 에러가 발생했습니다."),
 	// LMS_SERVER_ERROR(INTERNAL_SERVER_ERROR, "LMS 서버에서 에러가 발생했습니다.")
 	;

--- a/src/main/java/sopio/acha/common/exception/KutisPasswordErrorException.java
+++ b/src/main/java/sopio/acha/common/exception/KutisPasswordErrorException.java
@@ -1,0 +1,8 @@
+package sopio.acha.common.exception;
+
+import static sopio.acha.common.exception.GlobalExceptionCode.KUTIS_PASSWORD_ERROR;
+
+public class KutisPasswordErrorException extends CustomException{
+    public KutisPasswordErrorException(){super(KUTIS_PASSWORD_ERROR); }
+
+}

--- a/src/main/java/sopio/acha/common/exception/KutisPasswordErrorException.java
+++ b/src/main/java/sopio/acha/common/exception/KutisPasswordErrorException.java
@@ -1,7 +1,11 @@
 package sopio.acha.common.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import static sopio.acha.common.exception.GlobalExceptionCode.KUTIS_PASSWORD_ERROR;
 
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class KutisPasswordErrorException extends CustomException{
     public KutisPasswordErrorException(){super(KUTIS_PASSWORD_ERROR); }
 

--- a/src/main/java/sopio/acha/common/handler/ExtractorHandler.java
+++ b/src/main/java/sopio/acha/common/handler/ExtractorHandler.java
@@ -97,12 +97,7 @@ public class ExtractorHandler {
 			return new JSONObject(response.getBody());
 		} catch (HttpClientErrorException e) {
 			if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
-				String responseBody = e.getResponseBodyAsString();
-				JSONObject errorJson = new JSONObject(responseBody);
-
-				if (errorJson.has("message") && errorJson.getString("message").contains("비밀번호 변경")) {
-					throw new KutisPasswordErrorException();
-				}
+				throw new KutisPasswordErrorException();
 			}
 			throw e;
 		}

--- a/src/main/java/sopio/acha/common/handler/ExtractorHandler.java
+++ b/src/main/java/sopio/acha/common/handler/ExtractorHandler.java
@@ -10,14 +10,18 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import sopio.acha.common.exception.ExtractorErrorException;
+import sopio.acha.common.exception.KutisPasswordErrorException;
+
 
 @Component
 @RequiredArgsConstructor
@@ -54,7 +58,7 @@ public class ExtractorHandler {
 		URI uri = buildUriByPath("/v1/course/");
 		String requestBody = "{ \"studentId\": \"" + studentId + "\", \"password\": \"" + password
 			+ "\", \"year\": " + getCurrentSemesterYear() + ", \"semester\": " + getCurrentSemester()
-			+ ", \"extract\": false }";
+			+ ", \"extract\": true }";
 		return getJsonData(requestBody, uri).toString();
 	}
 
@@ -88,7 +92,19 @@ public class ExtractorHandler {
 		HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
 
 		RestTemplate restTemplate = new RestTemplate();
-		ResponseEntity<String> response = restTemplate.exchange(uri, POST, entity, String.class);
-		return new JSONObject(response.getBody());
+		try {
+			ResponseEntity<String> response = restTemplate.exchange(uri, POST, entity, String.class);
+			return new JSONObject(response.getBody());
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+				String responseBody = e.getResponseBodyAsString();
+				JSONObject errorJson = new JSONObject(responseBody);
+
+				if (errorJson.has("message") && errorJson.getString("message").contains("비밀번호 변경")) {
+					throw new KutisPasswordErrorException();
+				}
+			}
+			throw e;
+		}
 	}
 }

--- a/src/main/java/sopio/acha/domain/activity/application/ActivityService.java
+++ b/src/main/java/sopio/acha/domain/activity/application/ActivityService.java
@@ -78,14 +78,6 @@ public class ActivityService {
 		}
 	}
 
-	@Transactional
-	public void extractActivity(Member currentMember) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		List<MemberLecture> currentLectures = memberLectureService.getCurrentMemberLectureAndSetLastUpdatedAt(
-			currentMember);
-		saveExtractedActivity(currentLectures, objectMapper);
-	}
-
 	public void scheduledActivityExtraction() {
 		ObjectMapper objectMapper = new ObjectMapper();
 		List<MemberLecture> allLectureList = memberLectureService.getAllMemberLecture()

--- a/src/main/java/sopio/acha/domain/activity/presentation/ActivityController.java
+++ b/src/main/java/sopio/acha/domain/activity/presentation/ActivityController.java
@@ -24,15 +24,6 @@ import sopio.acha.domain.member.domain.Member;
 public class ActivityController {
 	private final ActivityService activityService;
 
-	@PostMapping
-	@Operation(summary = "활동 정보 스크래핑 요청 API", description = "활동 정보를 스크래핑하고 해당 데이터를 DB에 저장합니다.")
-	public ResponseEntity<Void> extractActivityAndSave(
-		@CurrentMember Member currentMember
-	) {
-		activityService.extractActivity(currentMember);
-		return ResponseEntity.ok().build();
-	}
-
 	@GetMapping("/my")
 	@Operation(summary = "내 활동 목록 조회 API", description = "활동 제출 남은 시간을 기준으로 활동 목록을 조회합니다.")
 	public ResponseEntity<ActivitySummaryListResponse> getMyActivityList(

--- a/src/main/java/sopio/acha/domain/lecture/application/ExtractActivities.java
+++ b/src/main/java/sopio/acha/domain/lecture/application/ExtractActivities.java
@@ -20,7 +20,7 @@ import java.util.stream.StreamSupport;
 
 @Component
 @RequiredArgsConstructor
-public class LectureServiceHelper {
+public class ExtractActivities {
     private final MemberLectureService memberLectureService;
     private final ActivityRepository activityRepository;
 

--- a/src/main/java/sopio/acha/domain/lecture/application/LectureService.java
+++ b/src/main/java/sopio/acha/domain/lecture/application/LectureService.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
-import sopio.acha.domain.activity.application.ActivityService;
 import sopio.acha.domain.lecture.domain.Lecture;
 import sopio.acha.domain.lecture.infrastructure.LectureRepository;
 import sopio.acha.domain.lecture.presentation.exception.FailedParsingLectureDataException;
@@ -29,7 +28,6 @@ import sopio.acha.domain.lecture.presentation.response.LectureBasicInformationRe
 import sopio.acha.domain.lecture.presentation.response.LectureTimeTableResponse;
 import sopio.acha.domain.member.domain.Member;
 import sopio.acha.domain.memberLecture.application.MemberLectureService;
-import sopio.acha.domain.memberLecture.domain.MemberLecture;
 import sopio.acha.domain.notification.application.NotificationService;
 
 @Service
@@ -38,7 +36,7 @@ public class LectureService {
 	private final LectureRepository lectureRepository;
 	private final MemberLectureService memberLectureService;
 	private final NotificationService notificationService;
-	private final LectureServiceHelper lectureServiceHelper;
+	private final ExtractActivities extractActivities;
 
 	@Transactional(propagation = REQUIRES_NEW)
 	public void extractLectureAndSave(Member currentMember) {
@@ -84,7 +82,7 @@ public class LectureService {
 					.map(this::getByIdentifier)
 					.toList();
 			memberLectureService.saveMyLectures(lectureHasTimeTable, currentMember);
-			lectureServiceHelper.saveLectureAndActivities(courseData, lectureHasTimeTable, currentMember, objectMapper);
+			extractActivities.saveLectureAndActivities(courseData, lectureHasTimeTable, currentMember, objectMapper);
 		} catch (JsonProcessingException e) {
 			throw new FailedParsingLectureDataException();
 		}

--- a/src/main/java/sopio/acha/domain/lecture/application/LectureServiceHelper.java
+++ b/src/main/java/sopio/acha/domain/lecture/application/LectureServiceHelper.java
@@ -51,7 +51,7 @@ public class LectureServiceHelper {
                         .map(activityResponse -> {
                             Activity activity = Activity.save(
                                 activityResponse.available(),
-                                0,
+                                week,
                                 activityResponse.title(),
                                 Optional.ofNullable(activityResponse.link()).orElse(""),
                                 activityResponse.type(),
@@ -69,8 +69,8 @@ public class LectureServiceHelper {
                         .toList());
                 }
             }
-            activityRepository.saveAll(activities);
         }
+        activityRepository.saveAll(activities);
     }
 
     private boolean isExistsActivity(String title, String memberId) {

--- a/src/main/java/sopio/acha/domain/lecture/application/LectureServiceHelper.java
+++ b/src/main/java/sopio/acha/domain/lecture/application/LectureServiceHelper.java
@@ -1,0 +1,79 @@
+package sopio.acha.domain.lecture.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import sopio.acha.domain.activity.domain.Activity;
+import sopio.acha.domain.activity.infrastructure.ActivityRepository;
+import sopio.acha.domain.activity.presentation.response.ActivityResponse;
+import sopio.acha.domain.lecture.domain.Lecture;
+import sopio.acha.domain.member.domain.Member;
+import sopio.acha.domain.memberLecture.application.MemberLectureService;
+import sopio.acha.domain.memberLecture.domain.MemberLecture;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+
+@Component
+@RequiredArgsConstructor
+public class LectureServiceHelper {
+    private final MemberLectureService memberLectureService;
+    private final ActivityRepository activityRepository;
+
+    public void saveLectureAndActivities(JsonNode courseData, List<Lecture> lectureHasTimeTable, Member currentMember, ObjectMapper objectMapper) {
+        List<Activity> activities = new ArrayList<>();
+
+        List<MemberLecture> memberLectures = lectureHasTimeTable.stream()
+                .filter(lecture -> !memberLectureService.isExistsMemberLecture(currentMember, lecture))
+                .map(lecture -> new MemberLecture(currentMember, lecture))
+                .toList();
+
+        for (MemberLecture memberLecture : memberLectures) {
+            for (JsonNode dataNode : courseData) {
+                JsonNode activitiesWrapper = dataNode.get("activities");
+                if (activitiesWrapper == null || !activitiesWrapper.isArray())
+                    continue;
+
+                for (JsonNode weekNode : activitiesWrapper) {
+                    int week = weekNode.get("week").asInt();
+                    JsonNode activityArray = weekNode.get("activities");
+                    if (activityArray == null || !activityArray.isArray())
+                        continue;
+
+                    activities.addAll(StreamSupport.stream(activityArray.spliterator(), false)
+                        .map(node -> objectMapper.convertValue(node, ActivityResponse.class))
+                        .filter(activityResponse -> !isExistsActivity(activityResponse.title(),
+                            memberLecture.getMember().getId()))
+                        .map(activityResponse -> {
+                            Activity activity = Activity.save(
+                                activityResponse.available(),
+                                0,
+                                activityResponse.title(),
+                                Optional.ofNullable(activityResponse.link()).orElse(""),
+                                activityResponse.type(),
+                                Optional.ofNullable(activityResponse.code()).orElse(""),
+                                Optional.ofNullable(activityResponse.deadline()).orElse(""),
+                                activityResponse.startAt(),
+                                activityResponse.lectureTime(),
+                                Optional.ofNullable(activityResponse.timeLeft()).orElse(""),
+                                Optional.ofNullable(activityResponse.description()).orElse(""),
+                                memberLecture.getLecture(),
+                                memberLecture.getMember()
+                            );
+                            return activity;
+                        })
+                        .toList());
+                }
+            }
+            activityRepository.saveAll(activities);
+        }
+    }
+
+    private boolean isExistsActivity(String title, String memberId) {
+        return activityRepository.existsActivityByTitleAndMemberId(title, memberId);
+    }
+}

--- a/src/main/java/sopio/acha/domain/memberLecture/application/MemberLectureService.java
+++ b/src/main/java/sopio/acha/domain/memberLecture/application/MemberLectureService.java
@@ -59,7 +59,7 @@ public class MemberLectureService {
 			DateHandler.getCurrentSemesterYear(), DateHandler.getCurrentSemester());
 	}
 
-	private boolean isExistsMemberLecture(Member currentMember, Lecture lecture) {
+	public boolean isExistsMemberLecture(Member currentMember, Lecture lecture) {
 		return !memberLectureRepository.existsByMemberAndLecture(currentMember, lecture);
 	}
 }

--- a/src/main/java/sopio/acha/domain/memberLecture/application/MemberLectureService.java
+++ b/src/main/java/sopio/acha/domain/memberLecture/application/MemberLectureService.java
@@ -45,15 +45,6 @@ public class MemberLectureService {
 	}
 
 	@Transactional
-	public List<MemberLecture> getCurrentMemberLectureAndSetLastUpdatedAt(Member currentMember) {
-		return memberLectureRepository.findAllByMemberIdAndLectureYearAndLectureSemesterOrderByLectureDayOrderAsc(
-				currentMember.getId(), DateHandler.getCurrentSemesterYear(), DateHandler.getCurrentSemester())
-			.stream()
-			.peek(MemberLecture::setLastUpdatedAt)
-			.toList();
-	}
-
-	@Transactional
 	public List<MemberLecture> getAllMemberLecture() {
 		return memberLectureRepository.findAllByLectureYearAndLectureSemesterOrderByLectureDayOrderAsc(
 			DateHandler.getCurrentSemesterYear(), DateHandler.getCurrentSemester());


### PR DESCRIPTION
## Summary

- 클라이언트에서 /v1/course 요청을 보낼 때

- 1. 서버에서 추출기 서버로 /v1/timetable/ 요청 보내고 패스워드 오류시 KUTIS_PASSWORD_ERROR 발생하여 /v1/course/ 요청 보내지 않고 예외처리 했습니다.
- 
- 2. /v1/course/ 요청시 activity도 같이 저장합니다.
-   a. 순환참조 문제 때문에 LectureServiceHelper 클래스 추가했습니다.


----- 참고
리팩토링 필수입니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 암호 변경이 필요할 경우, 사용자에게 명확한 안내 메시지가 표시됩니다.
  - 강의 및 활동 데이터 처리 로직이 개선되어 전반적인 데이터 관리 효율성이 향상되었습니다.
  
- **리팩토링**
  - 기존의 활동 추출 기능 일부가 제거되어 시스템이 단순화되었습니다.
  - 멤버 강의 관련 처리 방식이 개선되어 접근성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->