### PR TITLE
기존 refresh 토큰을 사용한 acccess token 발급

### DIFF
--- a/src/main/java/sopio/acha/domain/member/application/MemberService.java
+++ b/src/main/java/sopio/acha/domain/member/application/MemberService.java
@@ -53,6 +53,11 @@ public class MemberService {
 		if (loginMember.getExtract()) {
 			saveNewDeviceToken(request.deviceToken(), loginMember);
 		}
+		RefreshToken refreshToken = refreshTokenService.getExistingToken(request.studentId());
+		if (refreshToken != null) {
+			AccessToken accessToken = AccessToken.of(jwtCreator.generateToken(loginMember, Duration.ofHours(2)));
+			return MemberTokenResponse.of(accessToken.getAccessToken(), refreshToken.getRefreshToken(), loginMember.getExtract());
+		}
 		return issueAndSaveMemberToken(loginMember);
 	}
 
@@ -98,10 +103,6 @@ public class MemberService {
 		RefreshToken refreshToken = refreshTokenService.getRefreshTokenObject(request);
 		Member loginMember = getMemberById(refreshToken.getStudentId());
 		if (loginMember.getDeletedAt() != null) throw new MemberNotAuthenticatedException();
-		if (refreshTokenService.getExistingToken(loginMember.getId()) != null) {
-			AccessToken accessToken = AccessToken.of(jwtCreator.generateToken(loginMember, Duration.ofHours(2)));
-			return AccessTokenResponse.of(accessToken.getAccessToken());
-		}
 		return AccessTokenResponse.of(issueAndSaveMemberToken(loginMember).accessToken());
 	}
 

--- a/src/main/java/sopio/acha/domain/member/application/MemberService.java
+++ b/src/main/java/sopio/acha/domain/member/application/MemberService.java
@@ -98,8 +98,11 @@ public class MemberService {
 		RefreshToken refreshToken = refreshTokenService.getRefreshTokenObject(request);
 		Member loginMember = getMemberById(refreshToken.getStudentId());
 		if (loginMember.getDeletedAt() != null) throw new MemberNotAuthenticatedException();
-		AccessToken accessToken = AccessToken.of(jwtCreator.generateToken(loginMember, Duration.ofHours(2)));
-		return AccessTokenResponse.of(accessToken.getAccessToken());
+		if (refreshTokenService.getExistingToken(loginMember.getId()) != null) {
+			AccessToken accessToken = AccessToken.of(jwtCreator.generateToken(loginMember, Duration.ofHours(2)));
+			return AccessTokenResponse.of(accessToken.getAccessToken());
+		}
+		return AccessTokenResponse.of(issueAndSaveMemberToken(loginMember).accessToken());
 	}
 
 	public Member getMemberById(String studentId) {

--- a/src/main/java/sopio/acha/domain/member/application/RefreshTokenService.java
+++ b/src/main/java/sopio/acha/domain/member/application/RefreshTokenService.java
@@ -21,4 +21,8 @@ public class RefreshTokenService {
 		return refreshTokenRepository.findByRefreshToken(request.refreshToken())
 			.orElseThrow(RefreshTokenNotFoundException::new);
 	}
+
+	public RefreshToken getExistingToken(String studentId) {
+		return refreshTokenRepository.findByStudentId(studentId);
+	}
 }

--- a/src/main/java/sopio/acha/domain/member/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/sopio/acha/domain/member/infrastructure/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ import sopio.acha.domain.member.domain.RefreshToken;
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 	Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+	RefreshToken findByStudentId(String studentId);
 }


### PR DESCRIPTION
## Summary

다른 디바이스에서 같은 계정으로 로그인시 같은 refresh token 사용하여 access token 발급


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 인증 시 기존 인증 정보를 활용하여 토큰 발급 및 재발급 절차가 개선되었습니다.
  - 토큰 생성 및 관리 프로세스가 중앙 집중화되어 보안과 일관성이 향상되었습니다.
  - 학생 정보를 기반으로 한 인증 토큰 조회 기능이 추가되어 전반적인 로그인 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->